### PR TITLE
Force active

### DIFF
--- a/lib/semantic_menu.rb
+++ b/lib/semantic_menu.rb
@@ -6,7 +6,7 @@ class MenuItem
   include ActionView::Helpers::TagHelper,
           ActionView::Helpers::UrlHelper
   
-  attr_accessor :children, :link
+  attr_accessor :children, :link, :active
   cattr_accessor :controller
   
   def initialize(title, link, level, link_opts={})
@@ -34,7 +34,7 @@ class MenuItem
   end
   
   def active?
-    children.any?(&:active?) || on_current_page?
+    self.active || children.any?(&:active?) || on_current_page?
   end
   
   def on_current_page?

--- a/test/semantic_menu_test.rb
+++ b/test/semantic_menu_test.rb
@@ -24,6 +24,18 @@ class SemanticMenuTest < ActiveSupport::TestCase
                  MenuItem.new("title", "link", 2, :class => 'button').to_s
   end
   
+  def test_force_active_state
+    MenuItem.any_instance.stubs(:on_current_page?).returns(false)
+
+    menu = SemanticMenu.new nil, :class => 'mymenu' do |root|
+      root.add 'title', 'link' do |links|
+        links.active = true
+      end
+    end
+    
+    assert_equal '<ul class="mymenu"><li class="active"><a href="link">title</a></li></ul>', menu.to_s
+  end
+  
   def test_menu_item_with_one_child
     MenuItem.any_instance.stubs(:active?).returns(false)
     assert_equal '<ul class="mymenu"><li><a href="link">title</a></li></ul>', default_menu.to_s


### PR DESCRIPTION
Hello,  I ran into a situation where I had nested resources and the current_page? method no longer worked, so I added the ability to manually switch the active attribute.  Includes tests.  Let me know what you think.
